### PR TITLE
Minor tweaks to the PHP color scheme

### DIFF
--- a/Symfony2.xml
+++ b/Symfony2.xml
@@ -1318,7 +1318,7 @@
     </option>
     <option name="PHP_IDENTIFIER">
       <value>
-        <option name="FOREGROUND" value="aeaeae" />
+        <option name="FOREGROUND" value="ffffff" />
         <option name="BACKGROUND" />
         <option name="FONT_TYPE" value="0" />
         <option name="EFFECT_COLOR" />
@@ -1338,7 +1338,7 @@
     </option>
     <option name="PHP_NUMBER">
       <value>
-        <option name="FOREGROUND" value="56db3a" />
+        <option name="FOREGROUND" value="0084d4" />
         <option name="BACKGROUND" />
         <option name="FONT_TYPE" value="0" />
         <option name="EFFECT_COLOR" />


### PR DESCRIPTION
- Fix the font color for numbers to match the Symfony template
- Reset PHP identifier's font color back to white (was AEAEAE) but now I can't
  find the reference doc I used for matching. All Symfony pages now show white.
  Perhaps they changed the font color back to white in the docs on the site?
